### PR TITLE
fixed checkpoint loading (untested)

### DIFF
--- a/run_improved.py
+++ b/run_improved.py
@@ -11,7 +11,7 @@ import subprocess
 import yaml
 import numpy as np
 from deap import base, creator, tools
-from deap.tools import HallOfFame
+from deap.tools import HallOfFame, ParetoFront
 from src.utils.print_utils import print_population, print_scores, box_print, print_job_info
 from src.llm_utils import split_file, retrieve_base_code, mutate_prompts
 from src.cfg.constants import *
@@ -813,7 +813,7 @@ def createPopulation():
     population = toolbox.population(n=start_population_size)
     box_print("Batch Checking Created Genes", print_bbox_len=60, new_line_end=False)
     delayed_creation_check(population)
-    hof = tools.HallOfFame(hof_size)
+    hof = tools.ParetoFront()
 
 # Define the problem
 creator.create("FitnessMulti", base.Fitness, weights=FITNESS_WEIGHTS)  # Adjust weights as needed
@@ -867,7 +867,7 @@ if __name__ == "__main__":
         population = toolbox.population(n=start_population_size)
         box_print("Batch Checking Created Genes", print_bbox_len=60, new_line_end=False)
         delayed_creation_check(population)
-        hof = tools.HallOfFame(hof_size)
+        hof = tools.ParetoFront()
 
     # Evaluate the entire population
     for ind in population:

--- a/run_improved.py
+++ b/run_improved.py
@@ -788,13 +788,13 @@ def load_checkpoint(folder_name="checkpoints", checkpoint_file=None):
     if checkpoint_file is None:
         checkpoint_files = sorted(glob.glob(os.path.join(folder_name, 'checkpoint_gen_*.pkl')), key=extract_generation, reverse=True)
         checkpoint_file = checkpoint_files[0] if checkpoint_files else None
+        checkpoint_file = os.path.split(checkpoint_file)[1]
     if checkpoint_file:
         filepath = os.path.join(folder_name, checkpoint_file)
         with open(filepath, 'rb') as file:
             checkpoint_data = pickle.load(file)
         print(f"Loaded checkpoint from {filepath}")
-        checkpoint_filename = os.path.split(checkpoint_file)[1]
-        start_gen = int(checkpoint_filename.split('_')[2].split('.')[0])
+        start_gen = int(checkpoint_file.split('_')[2].split('.')[0])
         start_gen = start_gen + 1
         return checkpoint_data, start_gen
     return None, None


### PR DESCRIPTION
fixed error causing checkpoints to not load. Can be bypassed if no '_' characters are present in the paths to the checkpoint files